### PR TITLE
Poprawienie szybkości działania

### DIFF
--- a/src/Draughts.cpp
+++ b/src/Draughts.cpp
@@ -57,6 +57,7 @@ void Draughts::init()
     renderWindow.setVerticalSyncEnabled(Resources::VerticalSync);
     renderWindow.setKeyRepeatEnabled(Resources::KeyRepeat);
     renderWindow.setMouseCursorGrabbed(Resources::MouseCursorGrab);
+	renderWindow.setFramerateLimit(Resources::UpdateRate);
 
     float viewHeight = static_cast<float>(sideFieldsNumber) + 2.0f;
 

--- a/src/SingleThreadGameRunner.cpp
+++ b/src/SingleThreadGameRunner.cpp
@@ -33,7 +33,6 @@ void SingleThreadGameRunner::run()
         measureAfterUpdate = now();
 
         sleepDuration = nextUpdate - now();
-        sf::sleep(sleepDuration);
 
         measureBeforeRender = now();
         game->render();


### PR DESCRIPTION
Zamiast obliczania czasów i funkcji sleep (która budzi często za późno) użyto <code>RenderWindow::setFramerateLimit</code>.